### PR TITLE
update spark version to 2.3.0

### DIFF
--- a/demo/amqp-spark-driver/pom.xml
+++ b/demo/amqp-spark-driver/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-streaming_2.11</artifactId>
-            <version>2.0.0</version>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>io.radanalytics</groupId>


### PR DESCRIPTION
the radanalytics.io tooling is now deploying 2.3.0 as the default
version. this change will ensure that the example continues to work with
the upstream changes.